### PR TITLE
[Refactor/#23] : 프로그램 상세 조회 시 후기 무한 스크롤 구현

### DIFF
--- a/src/main/java/com/example/gonggong_server/review/api/controller/ReviewController.java
+++ b/src/main/java/com/example/gonggong_server/review/api/controller/ReviewController.java
@@ -36,9 +36,11 @@ public class ReviewController {
 
     @GetMapping("/list/{programId}")
     public ResponseEntity<ApiResponse<ReviewListResponseDTO>> getReviews(
-            @PathVariable Long programId
+            @PathVariable Long programId,
+            @RequestParam(name = "lastReviewId", defaultValue = "0") Long lastReviewId,
+            @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        ReviewListResponseDTO response = reviewService.getReviews(programId);
+        ReviewListResponseDTO response = reviewService.getReviews(programId, lastReviewId, size);
         return ApiResponse.success(SuccessStatus.OK, response);
     }
 }

--- a/src/main/java/com/example/gonggong_server/review/application/response/ReviewListResponseDTO.java
+++ b/src/main/java/com/example/gonggong_server/review/application/response/ReviewListResponseDTO.java
@@ -16,10 +16,12 @@ import java.util.Map;
 @AllArgsConstructor
 public class ReviewListResponseDTO {
     private List<ReviewDTO> reviews;
+    private Boolean hasNext;
 
-    public static ReviewListResponseDTO of(List<ReviewDTO> reviews) {
+    public static ReviewListResponseDTO of(List<ReviewDTO> reviews, Boolean hasNext) {
         return ReviewListResponseDTO.builder()
                 .reviews(reviews)
+                .hasNext(hasNext)
                 .build();
     }
 

--- a/src/main/java/com/example/gonggong_server/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/gonggong_server/review/application/service/ReviewService.java
@@ -13,6 +13,9 @@ import com.example.gonggong_server.user.domain.entity.User;
 import com.example.gonggong_server.user.domain.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -58,8 +61,14 @@ public class ReviewService {
         }
     }
 
-    public ReviewListResponseDTO getReviews(Long programId) {
-        List<Review> reviews = reviewRepository.findAllByProgramId(programId);
+    public ReviewListResponseDTO getReviews(Long programId, Long lastReviewId, int size) {
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<Review> reviews = reviewRepository.findReviews(programId, lastReviewId, pageable);
+
+        // 다음 조회할 데이터가 남아있는지 확인
+        boolean hasNext = reviews.size() == size + 1;
+        if (hasNext)
+            reviews = reviews.subList(0, size);
 
         // 리뷰 작성한 사용자 정보 조회
         List<User> users = userRepository.findAllByUserId(
@@ -72,6 +81,6 @@ public class ReviewService {
         List<ReviewListResponseDTO.ReviewDTO> reviewDTOs = reviews.stream()
                 .map(review -> ReviewListResponseDTO.ReviewDTO.of(review, userNicknames)).toList();
 
-        return ReviewListResponseDTO.of(reviewDTOs);
+        return ReviewListResponseDTO.of(reviewDTOs, hasNext);
     }
 }

--- a/src/main/java/com/example/gonggong_server/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/example/gonggong_server/review/domain/repository/ReviewRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface ReviewRepository {
     void deleteByUserId(Long userId);
     Review save(Review review);
+    List<Review> findReviews(Long programId, Long lastReviewId, Pageable pageable);
     List<Review> findAllByProgramId(Long programId);
     Page<Program> findReviewedPrograms(Pageable pageable);
 }

--- a/src/main/java/com/example/gonggong_server/review/intra/repository/JpaReviewRepository.java
+++ b/src/main/java/com/example/gonggong_server/review/intra/repository/JpaReviewRepository.java
@@ -7,10 +7,17 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 
 public interface JpaReviewRepository extends ReviewRepository, JpaRepository<Review, Long> {
+    @Query("SELECT r FROM Review r WHERE r.programId = :programId AND (:lastReviewId = 0 OR r.reviewId < :lastReviewId) ORDER BY r.createDate DESC")
+    List<Review> findReviews(@Param("programId") Long programId,
+                             @Param("lastReviewId") Long lastReviewId,
+                             Pageable pageable);
+
     @Query("SELECT r FROM Review r WHERE r.programId = :programId ORDER BY r.createDate DESC")
     List<Review> findAllByProgramId(Long programId);
 


### PR DESCRIPTION
## 관련 이슈번호
* Closes #23 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1시간

## 해결하려는 문제가 무엇인가요?
* 무한 스크롤이지만 성능 상 전체 조회는 좋지않아서 10개씩 더 가져오게 구현했습니다.

## 어떻게 해결했나요?
* 프론트가 마지막으로 읽은 reviewId를 담아서 요청하면 그 기준으로 더 불러올 데이터가 있으면 hasNext 를 true로 반환합니다.
<img width="783" alt="image" src="https://github.com/user-attachments/assets/697ef5b4-5f33-4d8e-b2b9-b2d6df000934">

