### PR TITLE
[Refactor/#30] : 마이페이지 무한스크롤 구현

### DIFF
--- a/src/main/java/com/example/gonggong_server/review/api/controller/ReviewController.java
+++ b/src/main/java/com/example/gonggong_server/review/api/controller/ReviewController.java
@@ -48,10 +48,10 @@ public class ReviewController {
     @GetMapping("/mypage")
     public ResponseEntity<ApiResponse<MyReviewListResponseDTO>> getMyReviews(
             @AuthenticationPrincipal String userInputId,
-            @RequestParam(value = "size", defaultValue = "5") int size,
-            @RequestParam(value = "page", defaultValue = "1") int page
+            @RequestParam(name = "lastReviewId", defaultValue = "0") Long lastReviewId,
+            @RequestParam(value = "size", defaultValue = "5") int size
     ) {
-        MyReviewListResponseDTO response = reviewService.getMyReviews(userInputId,size, page);
+        MyReviewListResponseDTO response = reviewService.getMyReviews(userInputId, size, lastReviewId);
         return ApiResponse.success(SuccessStatus.OK, response);
     }
 

--- a/src/main/java/com/example/gonggong_server/review/application/response/MyReviewListResponseDTO.java
+++ b/src/main/java/com/example/gonggong_server/review/application/response/MyReviewListResponseDTO.java
@@ -18,18 +18,14 @@ public class MyReviewListResponseDTO {
     private String nickName;
     private String userInputId;
     private List<MyReviewDTO> reviews;
-    private int totalReviewCount;
-    private int totalPage;
-    private int currentPage;
+    private Boolean hasNext;
 
-    public static MyReviewListResponseDTO of(String nickName, String userInputId, List<MyReviewDTO> reviews, int totalReviewCount, int totalPage, int currentPage){
+    public static MyReviewListResponseDTO of(String nickName, String userInputId, List<MyReviewDTO> reviewDTOs, Boolean hasNext){
         return MyReviewListResponseDTO.builder()
                 .nickName(nickName)
-                .reviews(reviews)
+                .reviews(reviewDTOs)
                 .userInputId(userInputId)
-                .totalReviewCount(reviews.size())
-                .totalPage(totalPage)
-                .currentPage(currentPage)
+                .hasNext(hasNext)
                 .build();
     }
 

--- a/src/main/java/com/example/gonggong_server/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/example/gonggong_server/review/domain/repository/ReviewRepository.java
@@ -15,7 +15,7 @@ public interface ReviewRepository {
     List<Review> findReviews(Long programId, Long lastReviewId, Pageable pageable);
     List<Review> findAllByProgramId(Long programId);
     Page<Program> findReviewedPrograms(Pageable pageable);
-    Page<Review> findReviews(Long userId, Pageable pageable);
+    int countByUserId(Long userId);
     Optional<Review> findByReviewId(Long reviewId);
     List<Review> findReviewsByUserId(Long userId, Long lastReviewId, Pageable pageable);
 }

--- a/src/main/java/com/example/gonggong_server/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/example/gonggong_server/review/domain/repository/ReviewRepository.java
@@ -17,5 +17,5 @@ public interface ReviewRepository {
     Page<Program> findReviewedPrograms(Pageable pageable);
     Page<Review> findReviews(Long userId, Pageable pageable);
     Optional<Review> findByReviewId(Long reviewId);
-    Optional<Review> findByUserId(Long userId);
+    List<Review> findReviewsByUserId(Long userId, Long lastReviewId, Pageable pageable);
 }

--- a/src/main/java/com/example/gonggong_server/review/intra/repository/JpaReviewRepository.java
+++ b/src/main/java/com/example/gonggong_server/review/intra/repository/JpaReviewRepository.java
@@ -28,6 +28,6 @@ public interface JpaReviewRepository extends ReviewRepository, JpaRepository<Rev
     @Query("SELECT DISTINCT p FROM Review r JOIN Program p ON r.programId = p.programId ORDER BY r.createDate DESC")
     Page<Program> findReviewedPrograms(Pageable pageable);
 
-    @Query("SELECT r FROM Review r WHERE r.userId = :userId")
-    Page<Review> findReviews(@Param("userId") Long userId, Pageable pageable);
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.userId = :userId")
+    int countByUserId(Long userId);
 }

--- a/src/main/java/com/example/gonggong_server/review/intra/repository/JpaReviewRepository.java
+++ b/src/main/java/com/example/gonggong_server/review/intra/repository/JpaReviewRepository.java
@@ -17,6 +17,11 @@ public interface JpaReviewRepository extends ReviewRepository, JpaRepository<Rev
                              @Param("lastReviewId") Long lastReviewId,
                              Pageable pageable);
 
+    @Query("SELECT r FROM Review r WHERE r.userId = :userId AND (:lastReviewId = 0 OR r.reviewId < :lastReviewId) ORDER BY r.createDate DESC")
+    List<Review> findReviewsByUserId(@Param("userId")Long userId,
+                                     @Param("lastReviewId") Long lastReviewId,
+                                     Pageable pageable);
+
     @Query("SELECT r FROM Review r WHERE r.programId = :programId ORDER BY r.createDate DESC")
     List<Review> findAllByProgramId(Long programId);
 

--- a/src/main/java/com/example/gonggong_server/scrap/api/controller/ScrapController.java
+++ b/src/main/java/com/example/gonggong_server/scrap/api/controller/ScrapController.java
@@ -37,10 +37,10 @@ public class ScrapController {
     @GetMapping
     public ResponseEntity<ApiResponse<ScrapListResponseDTO>> getScrapList(
             @AuthenticationPrincipal String userInputId,
-            @RequestParam(value = "size", defaultValue = "5") int size,
-            @RequestParam(value = "page", defaultValue = "1") int page
+            @RequestParam(name = "lastScrapId", defaultValue = "0") Long lastScrapId,
+            @RequestParam(value = "size", defaultValue = "5") int size
     ) {
-        ScrapListResponseDTO response = scrapService.getScrapList(userInputId,size, page);
+        ScrapListResponseDTO response = scrapService.getScrapList(userInputId, size, lastScrapId);
         return ApiResponse.success(SuccessStatus.OK, response);
     }
 }

--- a/src/main/java/com/example/gonggong_server/scrap/application/response/ScrapListResponseDTO.java
+++ b/src/main/java/com/example/gonggong_server/scrap/application/response/ScrapListResponseDTO.java
@@ -16,18 +16,21 @@ import java.util.List;
 public class ScrapListResponseDTO{
     private String nickName;
     private String userInputId;
+    private int reviewCount;
     private List<ScrapProgramDTO> scraps;
     private Boolean hasNext;
 
     public static ScrapListResponseDTO of(
             String nickName,
             String userInputId,
+            int reviewCount,
             List<ScrapProgramDTO> scraps,
             Boolean hasNext
     ) {
         return ScrapListResponseDTO.builder()
                 .nickName(nickName)
                 .userInputId(userInputId)
+                .reviewCount(reviewCount)
                 .scraps(scraps)
                 .hasNext(hasNext)
                 .build();

--- a/src/main/java/com/example/gonggong_server/scrap/application/response/ScrapListResponseDTO.java
+++ b/src/main/java/com/example/gonggong_server/scrap/application/response/ScrapListResponseDTO.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -18,22 +17,19 @@ public class ScrapListResponseDTO{
     private String nickName;
     private String userInputId;
     private List<ScrapProgramDTO> scraps;
-    private int totalPage;
-    private int currentPage;
+    private Boolean hasNext;
 
     public static ScrapListResponseDTO of(
             String nickName,
             String userInputId,
             List<ScrapProgramDTO> scraps,
-            int totalPage,
-            int currentPage
+            Boolean hasNext
     ) {
         return ScrapListResponseDTO.builder()
                 .nickName(nickName)
                 .userInputId(userInputId)
                 .scraps(scraps)
-                .totalPage(totalPage)
-                .currentPage(currentPage)
+                .hasNext(hasNext)
                 .build();
     }
     @Getter
@@ -41,6 +37,7 @@ public class ScrapListResponseDTO{
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ScrapProgramDTO {
+        private Long scrapId;
         private Long programId;
         private String programType;
         private String programName;
@@ -48,9 +45,10 @@ public class ScrapListResponseDTO{
         private String programAge;
         private String programDate;
 
-        public static ScrapListResponseDTO.ScrapProgramDTO of(Long programId, String programType,String programName, String facilityName,
+        public static ScrapListResponseDTO.ScrapProgramDTO of(Long scrapId, Long programId, String programType,String programName, String facilityName,
                                                            int startAge, int endAge, LocalDate startDate, LocalDate endDate) {
             return ScrapProgramDTO.builder()
+                    .scrapId(scrapId)
                     .programId(programId)
                     .programType(programType)
                     .programName(programName)

--- a/src/main/java/com/example/gonggong_server/scrap/application/service/ScrapService.java
+++ b/src/main/java/com/example/gonggong_server/scrap/application/service/ScrapService.java
@@ -5,6 +5,7 @@ import com.example.gonggong_server.global.status.ErrorStatus;
 import com.example.gonggong_server.program.domain.entity.Program;
 import com.example.gonggong_server.program.domain.repository.ProgramRepository;
 import com.example.gonggong_server.program.exception.ProgramException;
+import com.example.gonggong_server.review.domain.repository.ReviewRepository;
 import com.example.gonggong_server.scrap.application.response.ScrapListResponseDTO;
 import com.example.gonggong_server.scrap.domain.entity.Scrap;
 import com.example.gonggong_server.scrap.domain.repository.ScrapRepository;
@@ -26,6 +27,7 @@ public class ScrapService {
     private final UserRepository userRepository;
     private final ScrapRepository scrapRepository;
     private final ProgramRepository programRepository;
+    private final ReviewRepository reviewRepository;
 
     @Transactional
     public void scrapProgram(String userInputId, Long programId) {
@@ -72,6 +74,7 @@ public class ScrapService {
     }
     public ScrapListResponseDTO getScrapList(String userInputId, int size, Long lastScrapId) {
         User user = findUserById(userInputId);
+        int reviewCount = reviewRepository.countByUserId(user.getUserId());
 
         Pageable pageable = PageRequest.of(0, size + 1);
         List<Scrap> scraps = scrapRepository.findScraps(user.getUserId(), lastScrapId, pageable);
@@ -83,7 +86,7 @@ public class ScrapService {
 
         List<ScrapListResponseDTO.ScrapProgramDTO> scrapPrograms = convertScrapsToDTOs(scraps);
 
-        return buildScrapListResponse(user, scrapPrograms, hasNext);
+        return buildScrapListResponse(user, scrapPrograms, reviewCount, hasNext);
     }
 
     private List<ScrapListResponseDTO.ScrapProgramDTO> convertScrapsToDTOs(List<Scrap> scraps) {
@@ -106,10 +109,11 @@ public class ScrapService {
                 .toList();
     }
 
-    private ScrapListResponseDTO buildScrapListResponse(User user, List<ScrapListResponseDTO.ScrapProgramDTO> scrapPrograms, boolean hasNext) {
+    private ScrapListResponseDTO buildScrapListResponse(User user, List<ScrapListResponseDTO.ScrapProgramDTO> scrapPrograms, int reviewCount, boolean hasNext) {
         return ScrapListResponseDTO.of(
                 user.getNickName(),
                 user.getUserInputId(),
+                reviewCount,
                 scrapPrograms,
                 hasNext
         );

--- a/src/main/java/com/example/gonggong_server/scrap/application/service/ScrapService.java
+++ b/src/main/java/com/example/gonggong_server/scrap/application/service/ScrapService.java
@@ -12,7 +12,6 @@ import com.example.gonggong_server.scrap.exception.ScrapException;
 import com.example.gonggong_server.user.domain.entity.User;
 import com.example.gonggong_server.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -71,15 +70,20 @@ public class ScrapService {
             throw new ScrapException(ErrorStatus.NOT_SCRAPPED);
         }
     }
-    public ScrapListResponseDTO getScrapList(String userInputId, int pageSize, int pageIndex) {
+    public ScrapListResponseDTO getScrapList(String userInputId, int size, Long lastScrapId) {
         User user = findUserById(userInputId);
 
-        Pageable pageable = PageRequest.of(pageIndex - 1, pageSize);
-        Page<Scrap> scraps = scrapRepository.findScraps(user.getUserId(), pageable);
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<Scrap> scraps = scrapRepository.findScraps(user.getUserId(), lastScrapId, pageable);
 
-        List<ScrapListResponseDTO.ScrapProgramDTO> scrapPrograms = convertScrapsToDTOs(scraps.getContent());
+        // 다음 조회할 데이터가 남아있는지 확인
+        boolean hasNext = scraps.size() == size + 1;
+        if (hasNext)
+            scraps = scraps.subList(0, size);
 
-        return buildScrapListResponse(user, scrapPrograms, scraps);
+        List<ScrapListResponseDTO.ScrapProgramDTO> scrapPrograms = convertScrapsToDTOs(scraps);
+
+        return buildScrapListResponse(user, scrapPrograms, hasNext);
     }
 
     private List<ScrapListResponseDTO.ScrapProgramDTO> convertScrapsToDTOs(List<Scrap> scraps) {
@@ -88,6 +92,7 @@ public class ScrapService {
                     Program program = findProgramById(scrap.getProgramId());
 
                     return ScrapListResponseDTO.ScrapProgramDTO.of(
+                            scrap.getScrapId(),
                             program.getProgramId(),
                             program.getType(),
                             program.getProgramName(),
@@ -101,13 +106,12 @@ public class ScrapService {
                 .toList();
     }
 
-    private ScrapListResponseDTO buildScrapListResponse(User user, List<ScrapListResponseDTO.ScrapProgramDTO> scrapPrograms, Page<Scrap> scraps) {
+    private ScrapListResponseDTO buildScrapListResponse(User user, List<ScrapListResponseDTO.ScrapProgramDTO> scrapPrograms, boolean hasNext) {
         return ScrapListResponseDTO.of(
                 user.getNickName(),
                 user.getUserInputId(),
                 scrapPrograms,
-                scraps.getTotalPages(),
-                scraps.getNumber() + 1 
+                hasNext
         );
     }
 }

--- a/src/main/java/com/example/gonggong_server/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/com/example/gonggong_server/scrap/domain/repository/ScrapRepository.java
@@ -2,7 +2,6 @@ package com.example.gonggong_server.scrap.domain.repository;
 
 import com.example.gonggong_server.scrap.domain.entity.Scrap;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -11,7 +10,7 @@ public interface ScrapRepository {
     Scrap save(Scrap scrap);
     Boolean existsByUserIdAndProgramId(Long userId, Long programId);
     int deleteByUserIdAndProgramId(Long userId, Long programId);
-    Page<Scrap> findScraps(Long userId, Pageable pageable);
+    List<Scrap> findScraps(Long userId, Long lastScrapId, Pageable pageable);
     void deleteByUserId(Long userId);
     List<String> findTop3Types();
 }

--- a/src/main/java/com/example/gonggong_server/scrap/infra/repository/JpaScrapRepository.java
+++ b/src/main/java/com/example/gonggong_server/scrap/infra/repository/JpaScrapRepository.java
@@ -3,7 +3,6 @@ package com.example.gonggong_server.scrap.infra.repository;
 import com.example.gonggong_server.scrap.domain.entity.Scrap;
 import com.example.gonggong_server.scrap.domain.repository.ScrapRepository;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,8 +15,10 @@ public interface JpaScrapRepository extends ScrapRepository, JpaRepository<Scrap
     @Modifying
     @Query("DELETE FROM Scrap s WHERE s.userId = :userId AND s.programId = :programId")
     int deleteByUserIdAndProgramId(@Param("userId") Long userId, @Param("programId") Long programId);
-    @Query("SELECT s FROM Scrap s WHERE s.userId = :userId")
-    Page<Scrap> findScraps(@Param("userId") Long userId, Pageable pageable);
+    @Query("SELECT s FROM Scrap s WHERE s.userId = :userId AND (:lastScrapId = 0 OR s.scrapId < :lastScrapId) ORDER BY s.createDate DESC")
+    List<Scrap> findScraps(@Param("userId") Long userId,
+                           @Param("lastScrapId") Long lastScrapId,
+                           Pageable pageable);
     @Query("SELECT s.programType FROM Scrap s GROUP BY s.programType ORDER BY COUNT(s.programType) DESC LIMIT 3")
     List<String> findTop3Types();
 }


### PR DESCRIPTION
## 관련 이슈번호
* Closes #536

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 

## 해결하려는 문제가 무엇인가요?
* 나의 스크랩 조회 무한스크롤 구현
* 나의 후기 조회 무한스크롤 구현
* 후기 개수 조회 추가

## 어떻게 해결했나요?
* 프론트에서 마지막으로 조회한 후기ID or 스크랩ID를 주면 그 이후 페이지에 있는 데이터 가져오게 구현했습니다. 프론트는 hasNext 응답으로 이후에 더 데이터가 남아있는지 판단할 수 있습니다.
* 마이페이지에서 후기 개수를 조회하는 부분이 없어서 추가했습니다.
* 위 응답에 맞춰서 API 명세서 수정완료했습니다.
